### PR TITLE
fix: accept Ollama's empty-string format as no structured output

### DIFF
--- a/stdapi/types/ollama.py
+++ b/stdapi/types/ollama.py
@@ -17,8 +17,8 @@ _NS_PER_SECOND: int = 1_000_000_000
 #: Thinking levels accepted by ``think`` in addition to a boolean.
 ThinkLevel = Literal["low", "medium", "high", "max"]
 
-#: Structured-output request: the string ``json``, or a JSON schema object.
-ResponseFormat = Literal["json"] | dict[str, JsonValue]
+#: Structured-output request: ``json``, a JSON schema object, or ``""`` for none.
+ResponseFormat = Literal["", "json"] | dict[str, JsonValue]
 
 #: Model residency hint: a duration string (``5m``) or a number of seconds.
 KeepAlive = str | float
@@ -181,7 +181,10 @@ class _InferenceRequest(BaseModelRequest):
     model: str = Field(description="Model name.")
     format: ResponseFormat | None = Field(
         default=None,
-        description="Structured output: `json`, or a JSON schema the answer must match.",
+        description=(
+            "Structured output: `json`, or a JSON schema the answer must match. "
+            "An empty string asks for no structured output."
+        ),
     )
     options: ModelOptions | None = Field(
         default=None, description="Runtime generation options."

--- a/tests/test_ollama_types.py
+++ b/tests/test_ollama_types.py
@@ -282,6 +282,27 @@ def test_format_json_and_schema_map_onto_response_format() -> None:
     }
 
 
+def test_empty_format_asks_for_no_structured_output() -> None:
+    """`format: ""` means unstructured output, as it does upstream.
+
+    langchain-ollama sends `format: ""` on every call, so refusing it is a hard
+    failure on a request Ollama itself serves normally.
+
+    Ref: https://docs.ollama.com/openapi.yaml (ChatRequest.format)
+    """
+    params = adapter.to_chat_completion_params(
+        ChatRequest.model_validate(
+            {
+                "model": "m",
+                "messages": [{"role": "user", "content": "hi"}],
+                "format": "",
+            }
+        ),
+        "m",
+    )
+    assert params.response_format is None
+
+
 def test_a_bare_schema_is_closed_to_extra_properties() -> None:
     """Every object node gains `additionalProperties: false` unless it set one.
 
@@ -523,6 +544,18 @@ def test_generate_folds_the_system_prompt_into_a_message_list() -> None:
         "m",
     )
     assert [message.role for message in params.messages] == ["system", "user"]
+
+
+def test_generate_accepts_an_empty_format() -> None:
+    """The generate request accepts `format: ""` and asks for no schema.
+
+    Ref: https://docs.ollama.com/openapi.yaml (GenerateRequest.format)
+    """
+    params = adapter.to_chat_completion_params(
+        GenerateRequest.model_validate({"model": "m", "prompt": "hi", "format": ""}),
+        "m",
+    )
+    assert params.response_format is None
 
 
 def _sent_body(


### PR DESCRIPTION
## What

Accept the empty string `format: ""` on the Ollama chat and generate request models, treating it as "no structured output".

## Why

`format: ""` is legal upstream and means "no structured output". The vendor OpenAPI declares `GenerateRequest.format` as `oneOf [string, object]` with no enum, and Ollama's own server handles it explicitly:

```go
switch string(req.Format) { case `null`, `""`: // not set }
```

This gateway narrowed the type to `Literal["json"] | dict[str, JsonValue]`, so both `ChatRequest` and `GenerateRequest` raised `Input should be 'json'` and `stdapi/main.py` mapped that to HTTP 400 — a hard failure with no degraded path. It is not a documented limitation either.

This is not a rare edge case: `langchain-ollama` 0.1.x/0.2.x declare `format: Literal["", "json"] = ""` and include `"format": self.format` unconditionally in `_chat_params`, so those versions send `format: ""` on *every* call. They work against real Ollama and 400 on every request against this gateway.

## How

- `stdapi/types/ollama.py`: widen `ResponseFormat` to `Literal["", "json"] | dict[str, JsonValue]` and document in the `format` field description that an empty string asks for no structured output.
- No change to `_apply_options`: an empty string matches neither the `"json"` nor the dict branch, so no `response_format` is set — which is exactly the intended outcome. Adding a branch for it would be dead code.

## Tests

Two regression tests in `tests/test_ollama_types.py`, both asserting the request validates and `to_chat_completion_params(...).response_format is None`:

- `test_empty_format_asks_for_no_structured_output` (chat path)
- `test_generate_accepts_an_empty_format` (generate path, which shares `_InferenceRequest`)

Verification run locally:

```
uv run pytest tests/test_ollama_types.py -q --offline            # 40 passed
uv run pytest tests/test_ollama_chat.py tests/test_ollama_generate.py \
    tests/test_ollama_types.py tests/test_ollama_models.py -q --offline   # 51 passed, 35 skipped (live lanes)
uv run ruff check stdapi/types/ollama.py tests/test_ollama_types.py       # All checks passed
uv run ruff format --check stdapi/types/ollama.py tests/test_ollama_types.py
uv run mypy stdapi/types/ollama.py                                        # Success
```

Mutation check: reverting only the type widening (back to `Literal["json"]`) makes both new tests fail with the pydantic `Input should be 'json'` error, and restoring it turns them green — the tests genuinely guard the fix.

Fixes #227
