### PR TITLE
fix: echo background and safety_identifier on the Responses Converse path

### DIFF
--- a/stdapi/models/chat/_adapters/_openai_responses.py
+++ b/stdapi/models/chat/_adapters/_openai_responses.py
@@ -2550,6 +2550,8 @@ def _build_response_object(
         top_logprobs=request.top_logprobs,
         usage=usage,
         user=request.user,
+        background=request.background,
+        safety_identifier=request.safety_identifier,
     )
 
 

--- a/tests/test_openai_responses_failed_status.py
+++ b/tests/test_openai_responses_failed_status.py
@@ -6,10 +6,11 @@ Ref: https://developers.openai.com/api/reference/resources/responses/methods/ret
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import pytest
 
+from stdapi.models.chat._default import ChatModel
 from stdapi.routes import openai_responses
 from stdapi.types.openai_responses import Response, ResponseCreateParams, ResponseError
 from tests._helpers import make_model_details
@@ -116,16 +117,38 @@ def test_failed_response_without_error_uses_the_fallback_message(
     assert error["type"] == "server_error"
 
 
-@pytest.mark.usefixtures("failed_chat_backend")
-def test_background_failed_response_stays_200(app_client: TestClient) -> None:
+def test_background_failed_response_stays_200(
+    app_client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """A background request returns the failed terminal state as a 200 Response.
 
     ``background`` responses are polled, so the terminal ``failed`` state and
     its ``error`` object must stay readable on the Response object instead of
     being raised as an HTTP error.
 
+    Only the Bedrock call is stubbed here: the Response itself is built by the
+    real Converse adapter, so the ``background`` echo below pins production
+    behaviour rather than a hand-built stub Response.
+
     Ref: https://developers.openai.com/api/docs/guides/background
     """
+
+    async def _validate_model(
+        model_id: str, *_args: object, **_kwargs: object
+    ) -> ModelDetails:
+        return make_model_details(model_id)
+
+    async def _failed_converse(
+        _self: ChatModel, _bedrock_request: dict[str, Any]
+    ) -> dict[str, Any]:
+        return {
+            "output": {"message": {"role": "assistant", "content": []}},
+            "stopReason": "malformed_model_output",
+            "usage": {"inputTokens": 1, "outputTokens": 1, "totalTokens": 2},
+        }
+
+    monkeypatch.setattr(openai_responses, "validate_model", _validate_model)
+    monkeypatch.setattr(ChatModel, "converse", _failed_converse)
     response = app_client.post(
         "/v1/responses",
         json={"model": "amazon.nova-pro-v1:0", "input": "hi", "background": True},
@@ -137,6 +160,6 @@ def test_background_failed_response_stays_200(app_client: TestClient) -> None:
     assert body["background"] is True
     assert body["error"] == {
         "code": "server_error",
-        "message": "The model failed to generate output.",
+        "message": "The model failed to generate a valid response.",
     }
     assert body["output"] == []

--- a/tests/test_openai_responses_stream.py
+++ b/tests/test_openai_responses_stream.py
@@ -1448,6 +1448,23 @@ class TestEchoFields:
         )
         assert response.parallel_tool_calls is True
 
+    async def test_background_and_safety_identifier_are_echoed(self) -> None:
+        """background and safety_identifier are echoed on the response object.
+
+        Both are accepted but ignored on the Converse path (there is no
+        Bedrock equivalent), yet the requested values must come back
+        unchanged, like every other echoed request field.
+        """
+        response = await format_response(
+            "resp-1",
+            1.0,
+            "model",
+            _bedrock_response([{"text": "hi"}]),
+            _request(background=True, safety_identifier="user-1"),
+        )
+        assert response.background is True
+        assert response.safety_identifier == "user-1"
+
     async def test_streamed_created_at_is_int(self) -> None:
         """Streaming lifecycle and terminal events carry an int created_at.
 


### PR DESCRIPTION
## What

`openai.types.responses.Response` declares `background: Optional[bool]` and `safety_identifier: Optional[str]`. On the Converse (Bedrock) path the gateway's `_build_response_object` constructed the `Response` without those two fields, so they came back `None` and — with `response_model_exclude_none=True` — were absent from the JSON body. The Mantle path already returns both fields, so the two backends of the same route disagreed.

The gateway's convention is that ignored parameters are still echoed (`text.verbosity`, unsupported tool types, `top_logprobs`); `docs/api_openai_responses.md` says `background` is "accepted but ignored" but never says the value is not returned.

## Why

A client that sends `background`/`safety_identifier` (both legal per the SDK types) gets a response object silently missing them on the Converse path while the Mantle path echoes them. Low severity (both fields are documented optional; nothing in the official SDK dereferences them), but it is a backend-consistency and echo-contract bug, and the existing `test_background_failed_response_stays_200` pinned nothing in production (its assertion read the test's own stub, which echoed the value itself).

## How

- `stdapi/models/chat/_adapters/_openai_responses.py`: pass `background=request.background` and `safety_identifier=request.safety_identifier` through `_build_response_object`'s `Response(...)` constructor, next to `user=request.user`.
- `tests/test_openai_responses_stream.py`: new `TestEchoFields::test_background_and_safety_identifier_are_echoed` asserting both values come back unchanged through the real adapter.
- `tests/test_openai_responses_failed_status.py`: `test_background_failed_response_stays_200` now stubs only the Bedrock call (`ChatModel.converse`) and `validate_model`, letting the real Converse adapter build the `Response`; the 200-vs-502 gate assertions are unchanged.

## Tests

- `uv run pytest tests/test_openai_responses_stream.py tests/test_openai_responses_failed_status.py -q` → **52 passed** (env: `AWS_DEFAULT_REGION=us-east-1`, which the suite requires at import).
- Wider sanity: `tests/test_openai_responses.py` → 59 passed, 77 skipped.
- **Mutation check**: reverting the two echo lines makes `test_background_and_safety_identifier_are_echoed` fail (`background is None`), and restoring them makes it pass again — the test genuinely guards the fix.

## Notes

Implemented with AI assistance (OpenCode + muse-spark 1.3), reviewed and verified locally per the checks above.

Fixes #234