### PR TITLE
fix: accept output_compression=0 on the images surfaces

### DIFF
--- a/stdapi/routes/openai_images_edits.py
+++ b/stdapi/routes/openai_images_edits.py
@@ -275,7 +275,7 @@ async def edit_images(
         int,
         Form(
             description="The compression level (0-100%) for the generated images.",
-            ge=1,
+            ge=0,
             le=100,
         ),
     ] = 100,

--- a/stdapi/types/openai_images.py
+++ b/stdapi/types/openai_images.py
@@ -345,7 +345,7 @@ class ImageGenerateParams(_ImageBaseParams):
     output_compression: int = Field(
         description="Compression level (0-100%) for generated images.",
         default=100,
-        ge=1,
+        ge=0,
         le=100,
     )
     output_format: ImageOutputFormats | None = Field(
@@ -421,7 +421,7 @@ class _ImageEditCommonParams(_ImageBaseParams):
     output_compression: int = Field(
         description="Compression level (0-100%) for generated images.",
         default=100,
-        ge=1,
+        ge=0,
         le=100,
     )
     output_format: ImageOutputFormats | None = Field(

--- a/tests/test_openai_images_edits.py
+++ b/tests/test_openai_images_edits.py
@@ -1128,10 +1128,13 @@ class TestImagesEditsOutputEncodingParameters:
         assert job_kwargs["output_format"] == "jpeg"
         assert job_kwargs["output_compression"] == 42
 
-    def test_output_compression_below_the_minimum_is_rejected(
-        self, app_client: TestClient
+    def test_output_compression_zero_reaches_the_job(
+        self, app_client: TestClient, job_kwargs: dict[str, object]
     ) -> None:
-        """``output_compression=0`` is outside the documented 1-100 range."""
+        """``output_compression=0`` is accepted and forwarded verbatim.
+
+        Ref: stdapi/types/openai_images.py:_ImageEditCommonParams.output_compression
+        """
         response = app_client.post(
             "/v1/images/edits",
             json={
@@ -1140,6 +1143,25 @@ class TestImagesEditsOutputEncodingParameters:
                 "images": [{"image_url": "data:image/png;base64,aW1hZ2U="}],
                 "output_format": "jpeg",
                 "output_compression": 0,
+                "response_format": "b64_json",
+            },
+        )
+
+        assert job_kwargs["output_compression"] == 0
+        assert response.status_code != 422
+
+    def test_output_compression_below_the_minimum_is_rejected(
+        self, app_client: TestClient
+    ) -> None:
+        """``output_compression=-1`` is outside the documented 0-100 range."""
+        response = app_client.post(
+            "/v1/images/edits",
+            json={
+                "model": "stub-model",
+                "prompt": "Make it darker",
+                "images": [{"image_url": "data:image/png;base64,aW1hZ2U="}],
+                "output_format": "jpeg",
+                "output_compression": -1,
             },
         )
 

--- a/tests/test_openai_images_generations.py
+++ b/tests/test_openai_images_generations.py
@@ -1692,10 +1692,16 @@ class TestImageGenerationJobParameters:
         assert job_kwargs["output_compression"] == 42
         assert job_kwargs["output_format"] == "jpeg"
 
-    def test_output_compression_below_the_minimum_is_rejected(
-        self, app_client: TestClientType
+    def test_output_compression_zero_reaches_the_job(
+        self, app_client: TestClientType, job_kwargs: dict[str, Any]
     ) -> None:
-        """``output_compression=0`` is outside the documented 1-100 range."""
+        """``output_compression=0`` is accepted and forwarded verbatim.
+
+        OpenAI documents the range as 0-100 with no lower bound, and the
+        Responses ``image_generation`` tool surface already accepts 0.
+
+        Ref: stdapi/types/openai_images.py:ImageGenerateParams.output_compression
+        """
         response = app_client.post(
             "/v1/images/generations",
             json={
@@ -1703,6 +1709,23 @@ class TestImageGenerationJobParameters:
                 "prompt": "a cat",
                 "output_format": "jpeg",
                 "output_compression": 0,
+            },
+        )
+
+        assert job_kwargs["output_compression"] == 0
+        assert response.status_code != 422
+
+    def test_output_compression_below_the_minimum_is_rejected(
+        self, app_client: TestClientType
+    ) -> None:
+        """``output_compression=-1`` is outside the documented 0-100 range."""
+        response = app_client.post(
+            "/v1/images/generations",
+            json={
+                "model": "stub-model",
+                "prompt": "a cat",
+                "output_format": "jpeg",
+                "output_compression": -1,
             },
         )
 


### PR DESCRIPTION
## What

`output_compression=0` is accepted on the images surfaces (`POST /v1/images/generations`, `POST /v1/images/edits`) instead of being refused with HTTP 400.

## Why

OpenAI documents `output_compression` as "The compression level (0-100%)" with no lower bound, and the vendor OpenAPI declares no minimum; for the Responses `image_generation` tool it is explicitly `minimum: 0`.

The gateway was inconsistent with itself:

- `stdapi/types/openai_responses.py` already uses `ge=0` for the same parameter, so 0 was accepted on the Responses tool surface and 400'd on the images surface.
- `stdapi/utils.py` already validates `0 <= compression <= 100` and its encoder handles 0 (both JPEG and WebP encode fine at 0; WebP at 0 is materially smaller than at 1).

So the request validators were denying a capability the rest of the stack supports.

## How

- `stdapi/types/openai_images.py`: `ImageGenerateParams.output_compression` and `_ImageEditCommonParams.output_compression` changed `ge=1` -> `ge=0`.
- `stdapi/routes/openai_images_edits.py`: the multipart `Form(...)` validator for `output_compression` changed `ge=1` -> `ge=0` (the edit route's multipart surface bypasses the pydantic request model).
- `le=100` and the default of `100` are unchanged, and negative values are still rejected.

## Tests

The two existing tests that pinned `output_compression=0` as invalid encoded the bug. Each is replaced with a boundary pair:

- `test_output_compression_zero_reaches_the_job` — 0 passes validation and reaches the job as 0.
- `test_output_compression_below_the_minimum_is_rejected` — now uses `-1` and still expects the 400 `invalid_request_error`.

## Verification

- `pytest tests/test_openai_images_generations.py tests/test_openai_images_edits.py -k output_compression` -> 5 passed.
- Both full files -> 61 passed, 15 skipped. The 19 setup errors are pre-existing `NoCredentialsError` fixtures in this environment (no AWS credentials) and are unrelated to this change.
- Mutation check: restoring `ge=1` makes both new `test_output_compression_zero_reaches_the_job` tests fail; restoring the fix returns them to green, which confirms the new tests actually guard the boundary.

Fixes #232
